### PR TITLE
enforce github markdown rendering

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -101,6 +101,16 @@ highlight:
   auto_detect: false
   tab_replace:
 
+# Markdown
+marked:
+  gfm: true
+  pedantic: false
+  sanitize: false
+  tables: true
+  breaks: false
+  smartLists: true
+  smartypants: false
+
 # Category & Tag
 default_category: Redbrick
 category_map:

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lint": "eslint ."
   },
   "hexo": {
-    "version": "3.2.2"
+    "version": "3.3.1"
   },
   "dependencies": {
     "async": "^2.0.1",


### PR DESCRIPTION
as discussed in #165 
hexo by default does not obey all of the github markdown rules. 
these config changes have them follow all github md rules and make it easier for us change goign forward