### PR TITLE
Add link to helpdesk 2018 agm exam and update helpdesk page

### DIFF
--- a/source/help/exams/index.md
+++ b/source/help/exams/index.md
@@ -62,7 +62,7 @@ you must first pass an exam. Here are some exams from previous years.
 
 ## Helpdesk Test
 
-*   [2018 AGM](,/helpdesk-test-2018-agm)
+*   [2018 AGM](./helpdesk-test-2018-agm)
 *   [2017 EGM](./helpdesk-test-2017-egm)
 *   [2017 AGM](./helpdesk-test-2017-agm)
 *   [2016 EGM](./helpdesk-test-2016-egm)

--- a/source/help/exams/index.md
+++ b/source/help/exams/index.md
@@ -62,6 +62,7 @@ you must first pass an exam. Here are some exams from previous years.
 
 ## Helpdesk Test
 
+*   [2018 AGM](,/helpdesk-test-2018-agm)
 *   [2017 EGM](./helpdesk-test-2017-egm)
 *   [2017 AGM](./helpdesk-test-2017-agm)
 *   [2016 EGM](./helpdesk-test-2016-egm)

--- a/source/help/index.md
+++ b/source/help/index.md
@@ -5,13 +5,9 @@ type: cmt
 banner: helpdesk.jpg
 cmt:
   - position: Helpdesk
-    name: Cliodhna Harrison
-    nick: thegirl
-    image: thegirl.jpg
-  - position: Helpdesk
-    name: Nevan Oman Crowe
-    nick: branch
-    image: branch.jpg 
+    name: Conor Berns
+    nick: berns
+    image: berns.jpg
 keywords:
 - help
 - helpdesk


### PR DESCRIPTION
Closes #

### Description

Adds link to 2018 AGM Helpdesk exam and update members listed on Helpdesk page.

### Checklist

*I confirm that before I submitted this pull request I did the following:*

- [X] Confirmed that no other open PRs address this issue.
- [X] Checked out the latest version of the site.
- [X] Ran `yarn start` and confirmed that there were no issues.
- [X] Annotated my code with the relevant license information (if applicable).
